### PR TITLE
Update VM SKU due to deprecation of existing one

### DIFF
--- a/templates/deploy-infra.json
+++ b/templates/deploy-infra.json
@@ -104,7 +104,7 @@
         "templateUriReplComp": "[concat(uri(deployment().properties.templateLink.uri,'deploy-replication-components.json'))]",
         "templateUriReplItem": "[concat(uri(deployment().properties.templateLink.uri,'deploy-replication-item.json'))]",
         "templateUriWin": "[concat(uri(deployment().properties.templateLink.uri,'deploy-windows-vm.json'))]",
-        "vmSku": "Standard_D4s_v5",
+        "vmSku": "Standard_A4_v2",
         "vmWinPriServer1Name": "vmwpri1cffe",
         "vmWinPriServer1Ip": "10.0.2.5",
         "vmWinPriServer2Name": "vmwpri1cfbe",


### PR DESCRIPTION
Updated the existing SKU from Standard_D4s_v5 which is no longer available in region for testing to Standard_A4_v2. This is also a cheaper SKU which is better for it's demo purposes. 